### PR TITLE
Change last_modified to Zookeeper mtime and some stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ bin/
 lib/
 include/
 zookeeper/
+zookeeper.out
 .idea/
 distribute-*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ docs/_build
 bin/
 lib/
 include/
+zookeeper/
 .idea/
 distribute-*.tar.gz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+0.3 (unreleased)
+----------------
+
+Changes
+*******
+
+- Use the Zookeeper-provided mtime of a node as the last_modified
+  attribute, instead of client specific time.time()
+
+
 0.2.1 (02/16/2012)
 ------------------
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+APPNAME = zktools
 HERE = $(shell pwd)
 BIN = $(HERE)/bin
+NOSE = $(BIN)/nosetests -s --with-xunit
+PYTHON = $(BIN)/python
 ZOOKEEPER = $(BIN)/zookeeper
 
 .PHONY: zookeeper
@@ -13,3 +16,18 @@ $(ZOOKEEPER):
 	cp zoo.cfg bin/zookeeper/conf/
 
 zookeeper: 	$(ZOOKEEPER)
+
+all: build
+
+$(BIN)/python:
+	virtualenv-2.6 --no-site-packages --distribute .
+
+build: $(BIN)/python
+	$(PYTHON) setup.py develop
+	$(BIN)/pip install nose
+	$(BIN)/pip install Mock
+
+test:
+	$(BIN)/zookeeper/bin/zkServer.sh start $(HERE)/zoo.cfg
+	$(NOSE) --with-coverage --cover-package=$(APPNAME) --cover-inclusive $(APPNAME)
+	$(BIN)/zookeeper/bin/zkServer.sh stop $(HERE)/zoo.cfg

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ZOOKEEPER = $(BIN)/zookeeper
 $(ZOOKEEPER):
 	mkdir -p bin
 	cd bin && \
-	curl --silent http://mirrors.ibiblio.org/apache//zookeeper/stable/zookeeper-3.3.4.tar.gz | tar -zvx
+	curl --silent http://mirrors.ibiblio.org/apache//zookeeper/stable/zookeeper-3.3.4.tar.gz | tar -zx
 	mv bin/zookeeper-3.3.4 bin/zookeeper
 	cd bin/zookeeper && ant compile
 	cp zoo.cfg bin/zookeeper/conf/

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ It currently provides:
   in Zookeeper nodes.
 * ``Locks`` - A Zookeeper lock with support for
   non-blocking acquire, modeled on Python's Lock objects that also includes a
-  `Revocable Shared Locks with Freaking Laser Beams` described in the 
-  `Zookeeper Recipe's 
+  `Revocable Shared Locks with Freaking Laser Beams` described in the
+  `Zookeeper Recipe's
   <http://zookeeper.apache.org/doc/current/recipes.html#sc_recoverableSharedLocks>`_.
 
 See `the full docs`_ for more  information.

--- a/zktools/tests/test_node.py
+++ b/zktools/tests/test_node.py
@@ -27,13 +27,17 @@ class TestNode(TestBase):
         n2 = self.makeOne('/zkTestNode')
 
         eq_(n1.value, n2.value)
+        eq_(n1.last_modified, n2.last_modified)
 
+        old_modified = n1.last_modified
         n1.value = 942
 
         # It can take a fraction of a second on some machines on occasion
         # for the other value to update
         time.sleep(0.1)
         eq_(n1.value, n2.value)
+        eq_(n1.last_modified, n2.last_modified)
+        self.assertTrue(n1.last_modified > old_modified)
 
     def testJsonValue(self):
         n1 = self.makeOne('/zkTestNode', use_json=True)


### PR DESCRIPTION
I'm not sure if the choice of using time.time() for last_modified was deliberate. Or if there was a specific use-case for it. I think having a consistent time as per Zookeeper's mtime is a better default.

I mixed in some other small updates to the Makefile. I can pull that out into a separate request if need be :-)
