### PR TITLE
Move clint dependency to an extra.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ with open(os.path.join(here, 'CHANGES.rst')) as f:
     CHANGES = f.read()
 
 reqs = [
-    "clint>=0.3.0",
     "zc.zk>=0.7.0"
 ]
 
@@ -42,9 +41,12 @@ setup(
     zip_safe=False,
     tests_require=['pkginfo', 'Mock>=0.7', 'nose'],
     install_requires=reqs,
+    extras_require={
+        "CLI": ["clint>=0.3.0"],
+    },
     entry_points="""
     [console_scripts]
-    zooky = zktools.locking:lock_cli
+    zooky = zktools.locking:lock_cli [CLI]
 
     """
 )

--- a/zktools/locking.py
+++ b/zktools/locking.py
@@ -46,9 +46,6 @@ import threading
 import time
 from optparse import OptionParser
 
-from clint.textui import colored
-from clint.textui import columns
-from clint.textui import puts
 from zc.zk import ZooKeeper
 import zookeeper
 
@@ -489,6 +486,10 @@ def has_write_lock(keyname, children):
 
 def lock_cli():
     """Zktools Lock CLI"""
+    from clint.textui import colored
+    from clint.textui import columns
+    from clint.textui import puts
+
     usage = "usage: %prog COMMAND"
     parser = OptionParser(usage=usage)
     parser.add_option("--host", dest="host", type="str",


### PR DESCRIPTION
Since clint's only necessary when a human wants to use `zooky` it can be left out in the default case so it doesn't need to be installed on servers that humans don't use.
